### PR TITLE
endpoint management tools

### DIFF
--- a/endpoint-management-tools/CrashPlan-Alert_State.sh
+++ b/endpoint-management-tools/CrashPlan-Alert_State.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#fill in these three vairables into the script. Create an API client with at minimum the computer Read permission
+CP_Console="EditFromTemplate_CrashPlan_Server_Name"
+clientID="EditFromTemplate_CrashPlan_clientId"
+secret="EditFromTemplate_CrashPlan_client_secret"
+
+if [ "$CP_Console" == "" ] || [ "$clientID" == "" ] || [ "$secret" == "" ];then
+    echo "<result>Please ensure all variables are set in the extension attribute script.</result>"
+else
+    token=`/usr/bin/curl -X POST -u "$clientID:$secret" -H "Accept: application/json" "$CP_Console/api/v3/oauth/token?grant_type=client_credentials" | /usr/bin/sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p'`
+    if [ "$token" == "" ];then
+        echo "<result>Error with API client Authentication</result>"
+    elif [ -f /Library/Application\ Support/CrashPlan/.identity ];then
+        guid=$(/usr/bin/awk -F '=' '/guid/{print $2}' /Library/Application\ Support/CrashPlan/.identity)
+        result=$(/usr/bin/curl  -X GET --header 'Authorization: Bearer '$token -H "Accept: application/json" "$CP_Console/api/computer/$guid?idType=guid")
+        AlertStates=`echo $result | /usr/bin/sed -n 's/.*"alertStates":\["\([^"]*\)".*/\1/p'`
+        if [ "$AlertStates" == "" ] ;then
+            echo "<result>`echo $result | /usr/bin/sed -n 's/.*"description":"\([^"]*\)".*/\1/p'`</result>"
+        else
+            echo "<result>$AlertStates</result>"
+        fi
+    else
+        echo "<result>Not installed</result>"
+    fi
+fi

--- a/endpoint-management-tools/CrashPlan-LocalStats.sh
+++ b/endpoint-management-tools/CrashPlan-LocalStats.sh
@@ -1,0 +1,135 @@
+#!/bin/zsh
+#set -x #echo on
+
+#This script parses CrashPlan logs for values, and performs some logic with them to determine the status of the CrashPlan install.
+
+#The Following are the possible values for CrashPlan_message. These are states that CrashPlan can be in. Some of them have actions that can be taken to resolve the issue.
+    #Message: "Healthy. Recent Backup." 
+    #Action: None. CrashPlan is functioning correctly.
+    #Message: "Unhealthy, userHome path doesn't exist."
+    #Action: CrashPlan has likely detected the wrong user. Confirm that the detected user is accurate for the machine, and that your userHome detection logic is valid. Then Uninstall/Reinstall.
+    #Message: "Unhealthy. System is Authorized, No recent backup."
+    #Action: Confirm settings are correct, then pull logs and determine issues.
+    #Message: "Unhealthy. Logs not updating."
+    #Action: Confirm settings are correct, then pull logs and determine issues. If CrashPlan is also not running then after confirming no systematic issues Uninstall/Reinnstall.
+    #Message: "Healthy. System is likely not yet registered."
+    #Action: None. Device was installed recently and has not yet detected a user.
+    #Message: "Unhealthy. System not yet registered."
+    #Action: Determine why user detection is failing. Then resolve
+    #Message: "Unhealthy. System is Deauthorized."
+    #Action: Reauthorize the device, Uninstall, or Uninstall/Reinstall CrashPlan
+
+#Regex for matching within jamf:
+    #.*\[Healthy. Recent Backup.\].* 
+    #.*\[Unhealthy, userHome path doesn't exist.\].*
+    #.*\[Unhealthy. System is Authorized, No recent backup.\].*
+    #.*\[Unhealthy. Logs not updating.\].*
+    #.*\[Healthy. System is likely not yet registered.\].*
+    #.*\[Unhealthy. System not yet registered.\].*
+    #.*\[Unhealthy. System is Deauthorized.\].*
+
+#Define min_days_healthy as the amount of days an agent can be unregistered, not be backing up, or have the logs not being updated for before switching to an error state.
+min_days_healthy=7
+
+# CrashPlan Application Path
+CrashPlanPath="/Applications/CrashPlan.app"
+guid=$(/usr/bin/awk -F '=' '/guid/{print $2}' /Library/Application\ Support/CrashPlan/.identity 2>/dev/null)
+
+if [[ -d "$CrashPlanPath" ]]; then
+    CrashPlan_base_log_directory="/Library/Logs/CrashPlan/"
+else 
+    for user in /Users/*; do
+        if [[ -e "$user/Applications/CrashPlan.app" ]]; then
+            CrashPlanPath="$user/Applications/CrashPlan.app"
+            CrashPlan_base_log_directory="$user/Library/Logs/CrashPlan/"
+            guid=$(/usr/bin/awk -F '=' '/guid/{print $2}' "$user"/Library/Application\ Support/CrashPlan/.identity 2>/dev/null)
+            userInstall=". User based install."
+        fi
+    done
+fi
+# Sets value of CrashPlan Log files, change if running against local logs.
+CrashPlanAppLog="${CrashPlan_base_log_directory}app.log"
+CrashPlanServiceLog="${CrashPlan_base_log_directory}service.log.0"
+CrashPlanBackupLog="${CrashPlan_base_log_directory}backup_files.log.0"
+# Check if CrashPlan is installed before anything else, but record if a guid was found.
+if [[ ! -d "$CrashPlanPath" ]]; then
+    if [ -n "${guid}" ];then
+        echo "<result>Not Installed${userInstall}</result>"
+    else 
+        echo "<result>Not Installed, but CrashPlan .identiy found guid:${guid}${userInstall}</result>"
+    fi
+    exit 0
+fi
+# Checks if CrashPlan Client is Running
+CrashPlanRunning="$(/usr/bin/pgrep "CrashPlanService")"
+#get values from the App Log. checking to see if the log they are in exists first.
+if [ -f "${CrashPlanAppLog}" ];then
+    #Get the Authorized status of the endpoint. True means that a user is assigned to the device. False could mean that it's in user detection mode
+    Authorized=$(/usr/bin/awk '/ServiceModel.authorized/{print $3}' "$CrashPlanAppLog")
+    #Not currently used. If value is 0, no user is activly logged in to CrashPlan, but the agent could be deactivated
+    CrashPlanLoggedIn="$(/usr/bin/awk '/USERS/{getline; gsub("\,",""); print $1; exit }' "$CrashPlanAppLog")"
+    #Gets CrashPlan username, this can be filled if Authorized  is false and Logged in is 0.
+    CrashPlan_username="$(/usr/bin/awk '/USERS/{getline; gsub("\,",""); print $2; exit }' "$CrashPlanAppLog")"
+    CrashPlan_userHome="$(/usr/bin/awk -F'[<>]' '/userHome/{print $3}' "$CrashPlanAppLog")"
+    if [ -e "$CrashPlan_userHome" ]; then
+        CrashPlan_userHome_valid="true"
+    else
+        CrashPlan_userHome_valid="false"
+    fi
+fi
+#Find out if today is the first few days the agent was installed to be used if user detection is still running. 
+# Also Grab the most recent day the service log was written to to indicate last time the service was running.
+if [ -f "$CrashPlanServiceLog" ];then
+    #Get the last time the service log updated. If the service is running then the log will exist, and be updated today.
+    first_start_day=$(/usr/bin/awk '/STARTED CrashPlan Agent/{print substr($0,2,8);exit}' "$CrashPlanServiceLog")
+    #If we don't have a first started value in the log then we are probably good so grab the first line from the service.log.0 and use that date
+    if [ "${first_start_day}" = "" ];then
+        first_start_day=$(/usr/bin/awk '/^\[/{print substr($0,2,8);exit}' "$CrashPlanServiceLog")
+    fi
+    first_start_day_seconds=$(/bin/date -jf "%m.%d.%y" "$first_start_day" +%s)
+    days_since_first_start=$(($(( $(date +%s)   - $first_start_day_seconds)) / 86400))
+    service_log_update_seconds=$(/bin/date -r "${CrashPlanServiceLog}" +%s)
+    service_log_update_date=$(/bin/date -r "${CrashPlanServiceLog}" +%d-%b-%Y)
+    days_since_logs_updated=$(($(( $(date +%s)   - $service_log_update_seconds)) / 86400))
+fi
+#Grab the last time the backup files log was written to as a successfully proxy for when backup last happened on an agent.
+if [ -f "${CrashPlanBackupLog}" ];then 
+    lastBackupDate_seconds=$(/bin/date -r "${CrashPlanBackupLog}" +%s) # $(cat /Library/Logs/CrashPlan/service.log.{2..0} 2>/dev/null | egrep 'Backup STOPPED|Backup COMPLETED'| tail -n 1)
+    lastBackupDate_date=$(/bin/date -r "${CrashPlanBackupLog}" +%d-%b-%Y)
+    days_since_last_backup=$(($(( $(date +%s)   - $lastBackupDate_seconds)) / 86400))
+else
+    days_since_last_backup="unknown"
+fi
+if [[ -n "${CrashPlanRunning}" ]];then
+    CrashPlan_status="On${userInstall}"
+else
+    CrashPlan_status="Off${userInstall}"
+fi
+CrashPlan_message=""
+#CrashPlan message
+if [ "${Authorized}" = 'true' ];then
+    if [ "$days_since_logs_updated" -lt "$min_days_healthy" ];then
+        if [ "$days_since_last_backup" -le "$min_days_healthy" ];then
+            if [ "$CrashPlan_userHome_valid" = 'true' ];then
+                CrashPlan_message="Healthy. Recent Backup." 
+            else
+                CrashPlan_message="Unhealthy, userHome path does not exist."
+            fi
+        else
+            CrashPlan_message="Unhealthy. System is Authorized, No recent backup."
+        fi
+    else
+        CrashPlan_message="Unhealthy. Logs not updating."
+    fi
+else
+    if [ "${CrashPlan_username}" = "" ];then
+        if [ "$days_since_first_start" -lt "$min_days_healthy" ];then
+            CrashPlan_message="Healthy. System is likely not yet registered."
+        else 
+            CrashPlan_message="Unhealthy. System not yet registered."
+        fi
+    else
+        CrashPlan_message="Unhealthy. System is Deauthorized."
+    fi
+fi
+echo "<result>Status: ${CrashPlan_status}\n Message:[${CrashPlan_message}]\n Logged in: ${CrashPlan_username}, UserHome:${CrashPlan_userHome}, UserHome valid: ${CrashPlan_userHome_valid}\n Last Backup:${lastBackupDate_date}\n Logs last written:${service_log_update_date}\nGuid: ${guid}</result>"

--- a/endpoint-management-tools/Detect_CrashPlan_Status.ps1
+++ b/endpoint-management-tools/Detect_CrashPlan_Status.ps1
@@ -1,0 +1,205 @@
+﻿<# Detect_CrashPLan_Status.ps1
+Used to determine the status of the CrashPlan service on an endpoint. Used for troubleshooting and to give context to a CrashPlan install.
+
+Responses and Actions:
+
+Settings:
+Script can be configured to upload logs to a CrashPlan provided sharefile location, or a local network drive. 
+To Modify uncomment items in the SendLogs function, then uncomment all the calls to SendLogs.
+
+Exit code 0
+Healthy, no action needed. Possible Values for the 'CrashPlan State' value:
+    Healthy. System was first installed today.
+        No Action.
+    Healthy. System is Authorized and running.
+        No Action.
+    Healthy. System is likely not yet registered.
+        No Action
+Exit code 1
+Install is not health, action likely needed. Possible Values for the 'CrashPlan State' value:
+Unhealthy. System is Authorized and running, but userHome Path does not exist on the system.
+    CrashPlan's user detection logic returned a userHome value that does not exist on the endpoint and so the :user vairable will not work. Trigger a reinstall to fix.
+Unhealthy. System is Authorized and running, but backup has never happened.
+    Check settings for this system, confirm it has a valid user home, or that there are files in that location
+Unhealthy. System is Authorized and running, but backup has not happened for days= X
+    Check settings, get logs.
+Unhealthy. System is not registered for days=X
+    Check detection logic, check to make sure that we have a vaid possible userHome, or username.
+Unhealthy. Logs have not been updated for days=X
+    Grab logs then uninstall/reinstall. Uninstall/Reinstall CrashPlan
+Unhealthy. CrashPlan Service is not running, and can't start service.
+    Service Corrupted Uninstall/Reinstall CrashPlan.
+CrashPlan is not a service on this endpoint, likely not installed.
+    CrashPlan is not installed. Trigger an install if it should be. Confirm that a version of Code42 was not installed before installing CrashPlan.
+#>
+
+#$ErrorSystemPreference = "SilentlyContinue"
+
+#Test for all possible locations CrashPlan could be installed
+if (Test-Path -Path C:\ProgramData\CrashPlan\log\app.log -PathType Leaf) {
+    $CrashPlanBasePath = "C:\ProgramData\CrashPlan"
+    $UserInstall = $False
+}
+else {
+    get-childItem C:\Users | ForEach-Object {
+        if ((Test-path "C:\Users\${_}\AppData\Local\CrashPlan")) {
+            $CrashPlanBasePath = "C:\Users\$_\AppData\Local\CrashPlan"
+            $UserInstall = $True
+        }
+    }
+}
+
+function SendLogs($preFix) {
+    #the link below can be used in a stand alone fashion to manually upload files to CrashPlan as well as with this script.
+    $ShareFileLink = "Sharefile request link from CrashPlan Support"
+    $ShareFile = $ShareFileLink.Split("-")[1]
+    
+    Copy-Item -path $CrashPlanBasePath\log\ -Destination $CrashPlanBasePath\tmplog\ -Recurse
+
+    $LogFile = "$preFix"+$(hostname) +"-"+ $(get-date -format FileDateUniversal) +".zip"
+    $evtx_name="$preFix"+$(hostname)+"System.evtx"
+    $backupLogPath = "$CrashPlanBasePath\tmplog\$evtx_name"
+    $logfile = Get-CimInstance Win32_NTEventlogFile | Where-Object LogfileName -EQ "System"
+    Invoke-CimMethod -InputObject $logfile -MethodName BackupEventLog -Arguments @{ ArchiveFileName = $backupLogPath }
+    
+    Compress-Archive -Path $CrashPlanBasePath\tmplog\* -DestinationPath $CrashPlanBasePath\$LogFile
+    $logZip=$CrashPlanBasePath+'\'+$LogFile
+
+    ##Uncomment below to upload to a shared folder.
+    #$Destination = "\\netshare\DESTINATION\CrashPlan_Remediation_Logs" + $TimeStamp
+    #Copy-Item -Path $logZip -Destination $Destination -Force
+    ##UnComment Below to upload to CrashPlan ShareFile
+    #$shareFilePost=$(curl.exe -X POST -F File1=@"$logZip" "https://crashplan.sf-api.com/sf/v3/Shares($ShareFile)/Upload?Method=standard&raw=false&fileName=+$LogFile")
+    #$chunkUri = ($shareFilePost | convertFrom-json).ChunkUri
+    #curl.exe -k -F "File1=@$logZip" "$chunkUri"
+
+    Remove-Item $CrashPlanBasePath\tmplog -Recurse
+    Remove-Item $logZip
+}
+function CheckCrashPlanInstall {
+
+    $MinDaysHealthy = 7
+    if ( !$UserInstall) {
+        $CrashPlanService = Get-Service -name 'CrashPlan Service'
+        if (![string]::IsNullOrEmpty($CrashPlanService.Status)) {
+            if ($CrashPlanService.Status -eq 'Running') {
+                $CrashPlanRunning = $true
+            }
+        }
+    }
+    else {
+        $CrashPlanService = Get-Process -name 'CrashPlanService'
+        if ($CrashPlanService -ne $null) {
+                 $CrashPlanRunning = $true
+        }
+    }
+    #Get the Authorized status of the endpoint. True means that a user is assigned to the device. False could mean that it's in user detection mode
+    $AppLog = "$CrashPlanBasePath\log\app.log"
+    $ServiceLog = "$CrashPlanBasePath\log\service.log.0"
+    $BackupLog = "$CrashPlanBasePath\log\backup_files.log.0"
+    if (Test-Path -Path $AppLog -PathType Leaf) {
+                $serviceModel = Get-Content $AppLog | Select-String 'ServiceModel.authorized'
+                $Guid = $(Get-Content "$CrashPlanBasePath\.identity" | Select-String 'guid').ToString().split("= ")[1]
+                $Authorized = [System.Convert]::ToBoolean($("$serviceModel".Replace(" ","").Split("=")[1]))
+                $RegisteredUser = $($(Select-string -Path $AppLog 'USERS' -CaseSensitive -Context 1).Context.PostContext).Split(",")[1].Trim()
+
+                #userHome validation, does the path exist on disk.
+                $UserHomeLine = Get-Content $AppLog | Select-String 'userHome'
+                $UserHome = ($UserHomeLine -split '[<>]')[2]
+                $UserHomeValid = Test-Path -Path $UserHome
+    }
+    if (Test-Path -Path $ServiceLog -PathType Leaf) {
+             #Get the last time the service log updated. If the service is running then the log will exist.             
+            $ServiceLogLastUpdated = $(Get-Item -Path $ServiceLog).lastwritetime.Date | Get-Date -Format yyyy-MM-dd
+            $LogsLastUpdated =  $(NEW-TIMESPAN -Start $ServiceLogLastUpdated -End $(Get-Date)).Days
+            $FirstStartLine = $(get-content $ServiceLog | Select-String -pattern 'STARTED CrashPlan Agent' | Select-Object line -first 1)
+            if ($FirstStartLine -ne $null) {
+                $FirstStartDay = $FirstStartLine.Line.substring(1,16) | Get-Date
+                $FirstStartTimeSpan =  $(NEW-TIMESPAN -Start $FirstStartDay -End $(Get-Date)).Days
+            }
+            $NothingToDoCount = $(get-content $CrashPlanBasePath\log\service.log.0 | Select-String -pattern 'Periodic check: Nothing to do, indicate backup activity for all sets','scanDone. backupComplete=true' | Measure-Object | Select-Object -ExpandProperty Count)
+     }
+    if (Test-Path -Path $BackupLog -PathType Leaf) {
+        #Get Last Backup Time if the service is Authorized
+        $LastBackupDate_line = $(Get-Content $BackupLog | Select-Object -Last 1)
+        if ($LastBackupDate_line) {
+            $LastBackupDate = $LastBackupDate_line.substring(2,16) | Get-Date -Format yyyy-MM-dd
+        }
+        else {
+            $LastBackupDate = "null"
+        }
+        if ($LastBackupDate -ne "null") {
+            $BackupUpdated =  $(NEW-TIMESPAN -Start $LastBackupDate -End $(Get-Date)).Days
+        }
+    }
+    if ($CrashPlanService -ne $null) {
+        if ($CrashPlanRunning) {
+            if ($LogsLastUpdated -lt $MinDaysHealthy) {
+                if ($Authorized) {
+                    if ($UserHome) {
+                        if ($UserHomeValid = $false) {
+                            $PreRemediationDetectionError = "Unhealthy. System is Authorized and running, but userHome Path does not exist on the system."
+                            $errorStatus = 1
+                        }
+                    }
+                    if ($BackupUpdated -eq "null") {
+                        if (($FirstStartTimeSpan -eq 1) -or ($FirstStartTimeSpan -eq 0)) {
+                            $PreRemediationDetectionError = "Healthy. System was first installed today."
+                            $errorStatus = 0
+                        }
+                        else {
+                            #SendLogs("Auth_no_recent_backup-$guid-")
+                            $PreRemediationDetectionError = "Unhealthy. System is Authorized and running, but backup has not happened. Logs last updated days= $LogsLastUpdated ."
+                            $errorStatus = 1
+                        }
+                    }
+                    if ($BackupUpdated -le $MinDaysHealthy) {
+                        $PreRemediationDetectionError = "Healthy. System is Authorized and running."
+                        $errorStatus = 0
+                    }
+                    else {
+                        #SendLogs("Auth_no_recent_backup-$guid-")
+                        $PreRemediationDetectionError = "Unhealthy. System is Authorized and running, but backup has not happened for days=" + $BackupUpdated +," Nothing to do count= $NothingToDoCount \."
+                        $errorStatus = 0                    }
+                }
+                else {
+                    if ($FirstStartTimeSpan -lt $MinDaysHealthy) {
+                        $PreRemediationDetectionError = "Healthy. System is likely not yet registered."
+                        $errorStatus = 0
+                    }
+                    else {
+                        #SendLogs("Not_yet_registered-$guid-")
+                        $PreRemediationDetectionError = "Unhealthy. System is not registered for days= $FirstStartTimeSpan."
+                        $errorStatus = 1
+                    }
+                }
+            }
+            else {
+                #SendLogs("Logs_not_updating-")
+                $PreRemediationDetectionError = "Unhealthy. Logs have not been updated for days=$LogsLastUpdated."
+                $errorStatus = 1
+            }
+        }
+        else {
+            #SendLogs("service_not_running-$guid-")  
+            $PreRemediationDetectionError = "Unhealthy. CrashPlan Service is not running. Logs last updated= $ServiceLogLastUpdated  ."
+            $errorStatus = 1
+        }
+    }
+    else {
+        $PreRemediationDetectionError = "CrashPlanService is not a registered service on this endpoint, likely not installed."
+        $errorStatus = 1
+    }
+    $PreRemediationDetectionOutput = "CrashPlan Running:$CrashPlanRunning, CrashPlan State:[$PreRemediationDetectionError] Logged in:$RegisteredUser, Userhome:$UserHome, UserHome valid:$UserHomeValid, Last Backup:$LastBackupDate, Logs last written:$ServiceLogLastUpdated, Guid:$Guid"
+    return @($errorStatus,$PreRemediationDetectionOutput,$PreRemediationDetectionError)
+}
+
+$Output = CheckCrashPlanInstall
+
+$errorStatus = $Output[0]
+$PreRemediationDetectionOutput = $Output[1]
+$PreRemediationDetectionError = $Output[2]
+
+Write-Error $PreRemediationDetectionError
+Write-Output $PreRemediationDetectionOutput
+exit $errorStatus


### PR DESCRIPTION
Added tools for getting the state of a CrashPlan install with an endpoint management tool.

CrashPlan-LocalStats.sh - can be used in Jamf
Detect_CrashPlan_Status.ps1 - can be used in Azure