### PR TITLE
Refactor user detection script and update logic

### DIFF
--- a/user_detection/Mac/UserDetect_from_plists_and_dscl.sh
+++ b/user_detection/Mac/UserDetect_from_plists_and_dscl.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-#macuserdetection-plist.sh
+#UserDetect_from_plists_and_dscl.sh
 #for Endpoint Backup Agents
 #The following script is helpful if you use main MacOS MDMs for device management. 
 #The script reads a plist on the local machine that is populated with the email associated with the device from the MDM.  
 #It checks for JAMF Connect Plist, Kandji Global Variable Plist, Okta Network User Plist, or the CrashPlan Plist
-#last updated Mar 9, 2026
+#last updated Mar 13, 2026
 function main () { 
+    # Define admin usernames
+    ADMIN_USERS=("admin1" "admin2" "admin3")
+
     userrealname=$(id -P $(stat -f%Su /dev/console) | cut -d : -f 8)
     user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ && ! /loginwindow/ { print $3 }')
     jamfplistuser=$(defaults read "/Users/$user/Library/Preferences/com.jamf.connect.state" DisplayName)
@@ -13,18 +16,17 @@ function main () {
     crashplanplistuser=$(defaults read "/Library/Managed Preferences/com.crashplan.email" crashplanActivationEmail)
     kandjiplistuser=$(defaults read "/Library/Managed Preferences/io.kandji.globalvariables" EMAIL)
     kandjiplisteuser=$(defaults read "/Library/Managed Preferences/io.kandji.extensions" EMAIL)
-    kandjiplistduser=$(dscl . -read /Users/$user dsAttrTypeNative:io.kandji.KandjiLogin.LinkedAccount 2>/dev/null | awk -F ': ' '{print $2}')
+    kandjidscluser=$(dscl . -read /Users/$user dsAttrTypeNative:io.kandji.KandjiLogin.LinkedAccount 2>/dev/null | awk -F ': ' '{print $2}')
     oktanetworkuser=$(dscl . -read /Users/$user dsAttrTypeStandard:NetworkUser 2>/dev/null | awk -F ': ' '{print $2}')
     dLocalHostName=$(scutil --get LocalHostName)
 
     currentdate=$(date)
     AGENT_USERNAME=""
-    AGENT_USERNAME="@logged in user ($user)"
     writeLog "---"
     writeLog "-----------------------------------User Detection Run Start-----------------------------------"
     writeLog "---"
-    writeLog "Running user detection script: macuserdetection-plist.sh"
-    writeLog "Starting user detection...version 2025-03-09"
+    writeLog "Running user detection script: UserDetect_from_plists_and_dscl.sh"
+    writeLog "Starting user detection...version 2026-03-13"
     writeLog "$currentdate"
     writeLog "LocalHostName found ($dLocalHostName)"
     writeLog "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -35,7 +37,7 @@ function main () {
     writeLog "jamfplistsystemuser: ($jamfplistsystemuser)"
     writeLog "kandjiplistuser: ($kandjiplistuser)"
     writeLog "kandjiplisteuser: ($kandjiplisteuser)"
-    writeLog "kandjiplistduser: ($kandjiplistduser)"
+    writeLog "kandjidscluser: ($kandjidscluser)"
     writeLog "oktanetworkuser: ($oktanetworkuser)"
     writeLog "crashplanplistuser: ($crashplanplistuser)"
     writeLog "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -51,8 +53,8 @@ function main () {
     if [[ ! $kandjiplisteuser =~ "@"  ]] || [[ $jamfplistuser =~ "io.kandji.globalvariables.plist" ]]; then 
     	kandjiplisteuser="" 
     fi    
-    if [[ ! $kandjiplistduser =~ "@"  ]] || [[ $jamfplistuser =~ "dsAttrTypeNative:io.kandji.KandjiLogin.LinkedAccount" ]]; then 
-    	kandjiplistduser="" 
+    if [[ ! $kandjidscluser =~ "@"  ]] || [[ $jamfplistuser =~ "dsAttrTypeNative:io.kandji.KandjiLogin.LinkedAccount" ]]; then 
+    	kandjidscluser="" 
     fi    
     if [[ ! $oktanetworkuser =~ "@"  ]] || [[ $jamfplistuser =~ "doesn't exist" ]]; then 
     	oktanetworkuser="" 
@@ -64,48 +66,56 @@ function main () {
         writeLog "Users: ($userhome)"
     done
 
-    #Start of Plist Logic
     writeLog "~"
-    if [[ "$user" =~ ^(admin1|admin2|admin3)$ ]] || [[ -z "$user" ]]; then
+    # Check if user is in admin list
+    is_admin=0
+    for admin in "${ADMIN_USERS[@]}"; do
+        if [[ "$user" == "$admin" ]]; then
+            is_admin=1
+            break
+        fi
+    done
+    if [[ $is_admin -eq 1 ]] || [[ -z "$user" ]]; then
         writeLog "Excluded or null username detected ($user). Will retry user detection in 60 minutes, or when reboot occurs."
         exit
-    else
-      	if [[ -n "$jamfplistuser" ]]; then
-      		writeLog "Using JAMF Config Profile PLIST ($jamfplistuser)"
-      		AGENT_USERNAME="$jamfplistuser"
-      	elif [[ -n "$jamfplistsystemuser" ]]; then
-      		writeLog "Using JAMF Config Profile PLIST ($jamfplistsystemuser)"
-      		AGENT_USERNAME="$jamfplistsystemuser"
-      	elif [[ -n "$kandjiplistuser" ]]; then
-      		writeLog "Using Kandji Config Profile PLIST ($kandjiplistuser)"
-      		AGENT_USERNAME="$kandjiplistuser"
-      	elif [[ -n "$kandjiplisteuser" ]]; then
-      		writeLog "Using Kandji Config Profile PLIST ($kandjiplisteuser)"
-      		AGENT_USERNAME="$kandjiplisteuser"
-      	elif [[ -n "$kandjiplistduser" ]]; then
-      		writeLog "Using Kandji Config Profile PLIST ($kandjiplistduser)"
-      		AGENT_USERNAME="$kandjiplistduser"
-      	elif [[ -n "$oktanetworkuser" ]]; then
-      		writeLog "Using Okta Config Profile PLIST ($oktanetworkuser)"
-      		AGENT_USERNAME="$oktanetworkuser"
-      	elif [[ -n "$crashplanplistuser" ]]; then
-      	    writeLog "Using JAMF Connect PLIST ($crashplanplistuser)"
-      	    AGENT_USERNAME="$crashplanplistuser"
-      	elif [[ -z "$jamfplistuser" ]] && [[ -z "$crashplanplistuser" ]]; then
-    		writeLog "Known PLISTs empty $crashplanplistuser($crashplanplistuser) $jamfplistuser($jamfplistuser)"
-    		if [[ -z "$kandjiplistuser" ]] && [[ -z "$oktanetworkuser" ]]; then
-    			writeLog "Known PLISTs empty $kandjiplistuser($kandjiplistuser) $oktanetworkuser($oktanetworkuser)"
-    		fi
-      	    AGENT_USERNAME="@PLIST(s) are empty"
-      	fi
-        writeLog "Username read from plist ($AGENT_USERNAME)"
-        AGENT_USER_HOME=$(dscl . -read "/users/$user" NFSHomeDirectory | cut -d ' ' -f 2)
-        writeLog "Home directory read from dscl ($AGENT_USER_HOME)"
-        writeLog "Returning AGENT_USERNAME=$AGENT_USERNAME"
-        writeLog "Returning AGENT_USER_HOME=$AGENT_USER_HOME"
-        echo "AGENT_USERNAME=$AGENT_USERNAME"
-        echo "AGENT_USER_HOME=$AGENT_USER_HOME"
     fi
+    
+    #Start of Plist Logic
+    if [[ -n "$jamfplistuser" ]]; then
+        writeLog "Using JAMF Config Profile PLIST ($jamfplistuser)"
+        AGENT_USERNAME="$jamfplistuser"
+    elif [[ -n "$jamfplistsystemuser" ]]; then
+        writeLog "Using JAMF Config Profile PLIST ($jamfplistsystemuser)"
+        AGENT_USERNAME="$jamfplistsystemuser"
+    elif [[ -n "$kandjiplistuser" ]]; then
+        writeLog "Using Kandji Config Profile PLIST ($kandjiplistuser)"
+        AGENT_USERNAME="$kandjiplistuser"
+    elif [[ -n "$kandjiplisteuser" ]]; then
+        writeLog "Using Kandji Config Profile PLIST ($kandjiplisteuser)"
+        AGENT_USERNAME="$kandjiplisteuser"
+    elif [[ -n "$kandjidscluser" ]]; then
+        writeLog "Using Kandji Config Profile PLIST ($kandjidscluser)"
+        AGENT_USERNAME="$kandjidscluser"
+    elif [[ -n "$oktanetworkuser" ]]; then
+        writeLog "Using Okta Config Profile PLIST ($oktanetworkuser)"
+        AGENT_USERNAME="$oktanetworkuser"
+    elif [[ -n "$crashplanplistuser" ]]; then
+        writeLog "Using JAMF Connect PLIST ($crashplanplistuser)"
+        AGENT_USERNAME="$crashplanplistuser"
+    elif [[ -z "$jamfplistuser" && -z "$jamfplistsystemuser" && -z "$kandjiplistuser" && -z "$kandjiplisteuser" && -z "$kandjidscluser" && -z "$oktanetworkuser" && -z "$crashplanplistuser" ]]; then
+        # none of the plist lookups returned a value
+        writeLog "Known MDM variables empty"
+    fi
+
+    writeLog "Username read from plist ($AGENT_USERNAME)"
+    AGENT_USER_HOME=$(dscl . -read "/users/${user}" NFSHomeDirectory | cut -d ' ' -f 2)
+    writeLog "Home directory read from dscl ($AGENT_USER_HOME)"
+    writeLog "~"
+    writeLog "Returning AGENT_USERNAME=$AGENT_USERNAME"
+    writeLog "Returning AGENT_USER_HOME=$AGENT_USER_HOME"
+    writeLog "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "AGENT_USERNAME=$AGENT_USERNAME"
+    echo "AGENT_USER_HOME=$AGENT_USER_HOME"
 }
 function writeLog () {
     echo "$(date) - $@" >> /Library/Application\ Support/CrashPlan/log/userDetect_Result.log


### PR DESCRIPTION
Updated output for AGENT_USERNAME to be blank if none of the plist/dscl lookups returned a value. Removed fallback to ${user}.

Modified admin user check logic so that variables for customer editing are at the top.

Updated script name and last updated date. Changed variable name for dscl Kandji user detection. 